### PR TITLE
feat(user): employee account creation and domain validation coverage

### DIFF
--- a/src/main/java/com/plazoleta/usermicroservice/application/dto/request/LoginRequest.java
+++ b/src/main/java/com/plazoleta/usermicroservice/application/dto/request/LoginRequest.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record LoginRequest(
         @Schema(
                 description = "User's email address used for authentication. Must be a registered email in the system.",
-                example = "admin.example@mail.com",
+                example = "admin@plazoleta.com",
                 format = "email",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )

--- a/src/main/java/com/plazoleta/usermicroservice/application/dto/request/SaveUserRequest.java
+++ b/src/main/java/com/plazoleta/usermicroservice/application/dto/request/SaveUserRequest.java
@@ -13,7 +13,7 @@ public record SaveUserRequest(
 
         @Schema(
                 description = "User's last name. Must contain only letters and spaces.",
-                example = "Pérez García",
+                example = "Perez Garcia",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         String lastName,
@@ -49,7 +49,7 @@ public record SaveUserRequest(
 
         @Schema(
                 description = "User's email address. Must be a valid email format. Must be unique in the system.",
-                example = "juan.perez@empresa.com",
+                example = "juan.perez@plazoleta.com",
                 format = "email",
                 maxLength = 50,
                 requiredMode = Schema.RequiredMode.REQUIRED
@@ -62,6 +62,12 @@ public record SaveUserRequest(
                 minLength = 8,
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        String password
+        String password,
+        @Schema(
+                description = "User's role in the system. Must be 'OWNER' or 'EMPLOYEE'. 'OWNER' can create 'EMPLOYEE' users, 'EMPLOYEE' cannot create other users.",
+                example = "OWNER",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String role
 ) {
 }

--- a/src/main/java/com/plazoleta/usermicroservice/application/mappers/UserRequestMapper.java
+++ b/src/main/java/com/plazoleta/usermicroservice/application/mappers/UserRequestMapper.java
@@ -2,12 +2,20 @@ package com.plazoleta.usermicroservice.application.mappers;
 
 import com.plazoleta.usermicroservice.application.dto.request.SaveUserRequest;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.model.RoleModel;
+import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserRequestMapper {
-    
+
+    @org.mapstruct.Mapping(target = "role", expression = "java(toRoleModel(saveUserRequest.role()))")
     UserModel requestToModel(SaveUserRequest saveUserRequest);
+
+    default RoleModel toRoleModel(String role) {
+        if (role == null) return null;
+        return new RoleModel(null, RoleName.valueOf(role.toUpperCase()), null);
+    }
 }

--- a/src/main/java/com/plazoleta/usermicroservice/commons/config/beans/UserBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/usermicroservice/commons/config/beans/UserBeanConfiguration.java
@@ -11,6 +11,7 @@ import com.plazoleta.usermicroservice.domain.usecases.UserUseCase;
 import com.plazoleta.usermicroservice.domain.utils.validation.UserValidatorChain;
 import com.plazoleta.usermicroservice.infrastructure.adapters.persistence.UserPersistenceAdapter;
 import com.plazoleta.usermicroservice.infrastructure.mappers.UserEntityMapper;
+import com.plazoleta.usermicroservice.infrastructure.repositories.postgres.RoleRepository;
 import com.plazoleta.usermicroservice.infrastructure.repositories.postgres.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,11 @@ public class UserBeanConfiguration {
     private final UserRepository userRepository;
     private final UserEntityMapper userEntityMapper;
     private final PasswordEncoderPort passwordEncoderPort;
+    private final RoleRepository roleRepository;
 
     @Bean
     public UserPersistencePort userPersistencePort() {
-        return new UserPersistenceAdapter(userRepository, userEntityMapper);
+        return new UserPersistenceAdapter(userRepository, userEntityMapper, roleRepository);
     }
     
     @Bean

--- a/src/main/java/com/plazoleta/usermicroservice/commons/config/beans/UserBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/usermicroservice/commons/config/beans/UserBeanConfiguration.java
@@ -1,6 +1,10 @@
 package com.plazoleta.usermicroservice.commons.config.beans;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import com.plazoleta.usermicroservice.domain.ports.in.UserServicePort;
+import com.plazoleta.usermicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.usermicroservice.domain.ports.out.PasswordEncoderPort;
 import com.plazoleta.usermicroservice.domain.ports.out.UserPersistencePort;
 import com.plazoleta.usermicroservice.domain.usecases.UserUseCase;
@@ -8,9 +12,8 @@ import com.plazoleta.usermicroservice.domain.utils.validation.UserValidatorChain
 import com.plazoleta.usermicroservice.infrastructure.adapters.persistence.UserPersistenceAdapter;
 import com.plazoleta.usermicroservice.infrastructure.mappers.UserEntityMapper;
 import com.plazoleta.usermicroservice.infrastructure.repositories.postgres.UserRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
@@ -33,12 +36,14 @@ public class UserBeanConfiguration {
     @Bean
     public UserServicePort userServicePort(
             UserPersistencePort userPersistencePort,
-            UserValidatorChain userValidatorChain
+            UserValidatorChain userValidatorChain,
+            AuthenticatedUserPort authenticatedUserPort
     ) {
         return new UserUseCase(
                 userPersistencePort,
                 passwordEncoderPort,
-                userValidatorChain
+                userValidatorChain,
+                authenticatedUserPort
         );
     }
 }

--- a/src/main/java/com/plazoleta/usermicroservice/domain/exceptions/RoleNotAllowedException.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/exceptions/RoleNotAllowedException.java
@@ -1,0 +1,8 @@
+package com.plazoleta.usermicroservice.domain.exceptions;
+
+public class RoleNotAllowedException extends IllegalStateException {
+    
+    public RoleNotAllowedException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/plazoleta/usermicroservice/domain/ports/out/AuthenticatedUserPort.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/ports/out/AuthenticatedUserPort.java
@@ -1,0 +1,9 @@
+package com.plazoleta.usermicroservice.domain.ports.out;
+
+import java.util.List;
+
+public interface AuthenticatedUserPort {
+    
+    Long getCurrentUserId();
+    List<String> getCurrentUserRoles();
+}

--- a/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
@@ -5,11 +5,13 @@ import java.util.Optional;
 
 import com.plazoleta.usermicroservice.domain.exceptions.ElementAlreadyExistsException;
 import com.plazoleta.usermicroservice.domain.exceptions.ElementNotFoundException;
+import com.plazoleta.usermicroservice.domain.exceptions.RoleNotAllowedException;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
 import com.plazoleta.usermicroservice.domain.ports.in.UserServicePort;
 import com.plazoleta.usermicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.usermicroservice.domain.ports.out.PasswordEncoderPort;
 import com.plazoleta.usermicroservice.domain.ports.out.UserPersistencePort;
+import com.plazoleta.usermicroservice.domain.utils.constants.DomainConstants;
 import com.plazoleta.usermicroservice.domain.utils.constants.DomainExceptionsConstants;
 import com.plazoleta.usermicroservice.domain.utils.validation.UserValidatorChain;
 
@@ -31,44 +33,10 @@ public class UserUseCase implements UserServicePort {
     @Override
     public void save(UserModel userModel) {
         userValidatorChain.validate(userModel);
-
-        List<String> currentRoles = authenticatedUserPort.getCurrentUserRoles()
-                .stream()
-                .map(String::toUpperCase)
-                .toList();
-
-        String roleToCreate = userModel.getRole().getRoleEnum().toString().toUpperCase();
-
-        if (roleToCreate.equals("EMPLOYEE") && !currentRoles.contains("OWNER")) {
-            throw new RuntimeException("Only an OWNER can create an EMPLOYEE.");
-        }
-        if (roleToCreate.equals("OWNER") && !currentRoles.contains("ADMIN")) {
-            throw new RuntimeException("Only an ADMIN can create an OWNER.");
-        }
-
-        Optional<UserModel> userByDocument = userPersistencePort.getUserByDocumentId(userModel.getDocumentId());
-        if (userByDocument.isPresent()) {
-            throw new ElementAlreadyExistsException(
-                    String.format(DomainExceptionsConstants.USER_DOCUMENT_ID_ALREADY_EXIST_MESSAGE,
-                            userModel.getDocumentId()));
-        }
-
-        Optional<UserModel> userByEmail = userPersistencePort.getUserByEmail(userModel.getEmail());
-        if (userByEmail.isPresent()) {
-            throw new ElementAlreadyExistsException(
-                    String.format(DomainExceptionsConstants.USER_EMAIL_ALREADY_EXIST_MESSAGE, userModel.getEmail()));
-        }
-
-        Optional<UserModel> userByPhone = userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber());
-        if (userByPhone.isPresent()) {
-            throw new ElementAlreadyExistsException(
-                    String.format(DomainExceptionsConstants.USER_PHONE_NUMBER_ALREADY_EXIST_MESSAGE,
-                            userModel.getPhoneNumber()));
-        }
-
+        validateRoleAuthorization(userModel);
+        validateUserUniqueness(userModel);
         String encodedPassword = passwordEncoderPort.encode(userModel.getPassword());
         userModel.setPassword(encodedPassword);
-
         userPersistencePort.save(userModel);
     }
 
@@ -81,5 +49,39 @@ public class UserUseCase implements UserServicePort {
                     String.format(DomainExceptionsConstants.USER_NOT_FOUND_BY_ID_MESSAGE, id));
         }
         return user.get();
+    }
+
+    private void validateRoleAuthorization(UserModel userModel) {
+        List<String> currentRoles = authenticatedUserPort.getCurrentUserRoles()
+                .stream()
+                .map(String::toUpperCase)
+                .toList();
+        String roleToCreate = userModel.getRole().getRoleEnum().toString().toUpperCase();
+        if (roleToCreate.equals(DomainConstants.ROLE_EMPLOYEE) && !currentRoles.contains(DomainConstants.ROLE_OWNER)) {
+            throw new RoleNotAllowedException(DomainExceptionsConstants.ONLY_OWNER_CAN_CREATE_EMPLOYEE);
+        }
+        if (roleToCreate.equals(DomainConstants.ROLE_OWNER) && !currentRoles.contains(DomainConstants.ROLE_ADMIN)) {
+            throw new RoleNotAllowedException(DomainExceptionsConstants.ONLY_ADMIN_CAN_CREATE_OWNER);
+        }
+    }
+
+    private void validateUserUniqueness(UserModel userModel) {
+        Optional<UserModel> userByDocument = userPersistencePort.getUserByDocumentId(userModel.getDocumentId());
+        if (userByDocument.isPresent()) {
+            throw new ElementAlreadyExistsException(
+                    String.format(DomainExceptionsConstants.USER_DOCUMENT_ID_ALREADY_EXIST_MESSAGE,
+                            userModel.getDocumentId()));
+        }
+        Optional<UserModel> userByEmail = userPersistencePort.getUserByEmail(userModel.getEmail());
+        if (userByEmail.isPresent()) {
+            throw new ElementAlreadyExistsException(
+                    String.format(DomainExceptionsConstants.USER_EMAIL_ALREADY_EXIST_MESSAGE, userModel.getEmail()));
+        }
+        Optional<UserModel> userByPhone = userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber());
+        if (userByPhone.isPresent()) {
+            throw new ElementAlreadyExistsException(
+                    String.format(DomainExceptionsConstants.USER_PHONE_NUMBER_ALREADY_EXIST_MESSAGE,
+                            userModel.getPhoneNumber()));
+        }
     }
 }

--- a/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
@@ -1,33 +1,47 @@
 package com.plazoleta.usermicroservice.domain.usecases;
 
+import java.util.List;
+import java.util.Optional;
+
 import com.plazoleta.usermicroservice.domain.exceptions.ElementAlreadyExistsException;
 import com.plazoleta.usermicroservice.domain.exceptions.ElementNotFoundException;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
 import com.plazoleta.usermicroservice.domain.ports.in.UserServicePort;
+import com.plazoleta.usermicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.usermicroservice.domain.ports.out.PasswordEncoderPort;
 import com.plazoleta.usermicroservice.domain.ports.out.UserPersistencePort;
-import com.plazoleta.usermicroservice.domain.utils.constants.DomainConstants;
 import com.plazoleta.usermicroservice.domain.utils.constants.DomainExceptionsConstants;
 import com.plazoleta.usermicroservice.domain.utils.validation.UserValidatorChain;
-
-import java.util.Optional;
 
 public class UserUseCase implements UserServicePort {
 
     private final UserPersistencePort userPersistencePort;
     private final PasswordEncoderPort passwordEncoderPort;
     private final UserValidatorChain userValidatorChain;
+    private final AuthenticatedUserPort authenticatedUserPort;
 
     public UserUseCase(UserPersistencePort userPersistencePort, PasswordEncoderPort passwordEncoderPort,
-            UserValidatorChain userValidatorChain) {
+            UserValidatorChain userValidatorChain, AuthenticatedUserPort authenticatedUserPort) {
         this.userPersistencePort = userPersistencePort;
         this.passwordEncoderPort = passwordEncoderPort;
         this.userValidatorChain = userValidatorChain;
+        this.authenticatedUserPort = authenticatedUserPort;
     }
 
     @Override
     public void save(UserModel userModel) {
         userValidatorChain.validate(userModel);
+
+        List<String> currentRoles = authenticatedUserPort.getCurrentUserRoles();
+        String roleToCreate = userModel.getRole().toString();
+
+        if (roleToCreate.equals("EMPLOYEE") && !currentRoles.contains("OWNER")) {
+            throw new RuntimeException("Only an OWNER can create an EMPLOYEE.");
+        }
+
+        if (roleToCreate.equals("OWNER") && !currentRoles.contains("ADMIN")) {
+            throw new RuntimeException("Only an ADMIN can create an OWNER.");
+        }
 
         Optional<UserModel> userByDocument = userPersistencePort.getUserByDocumentId(userModel.getDocumentId());
         if (userByDocument.isPresent()) {
@@ -51,7 +65,6 @@ public class UserUseCase implements UserServicePort {
 
         String encodedPassword = passwordEncoderPort.encode(userModel.getPassword());
         userModel.setPassword(encodedPassword);
-        userModel.setRole(DomainConstants.OWNER_ROLE);
 
         userPersistencePort.save(userModel);
     }

--- a/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCase.java
@@ -32,13 +32,16 @@ public class UserUseCase implements UserServicePort {
     public void save(UserModel userModel) {
         userValidatorChain.validate(userModel);
 
-        List<String> currentRoles = authenticatedUserPort.getCurrentUserRoles();
-        String roleToCreate = userModel.getRole().toString();
+        List<String> currentRoles = authenticatedUserPort.getCurrentUserRoles()
+                .stream()
+                .map(String::toUpperCase)
+                .toList();
+
+        String roleToCreate = userModel.getRole().getRoleEnum().toString().toUpperCase();
 
         if (roleToCreate.equals("EMPLOYEE") && !currentRoles.contains("OWNER")) {
             throw new RuntimeException("Only an OWNER can create an EMPLOYEE.");
         }
-
         if (roleToCreate.equals("OWNER") && !currentRoles.contains("ADMIN")) {
             throw new RuntimeException("Only an ADMIN can create an OWNER.");
         }

--- a/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainConstants.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainConstants.java
@@ -25,6 +25,10 @@ public final class DomainConstants {
     public static final String EMAIL_FIELD = "email";
     public static final String PASSWORD_FIELD = "password";
 
+    public static final String ROLE_ADMIN = "ADMIN";
+    public static final String ROLE_OWNER = "OWNER";
+    public static final String ROLE_EMPLOYEE = "EMPLOYEE";
+
     private DomainConstants() {
 
         throw new IllegalStateException("Utility Class");

--- a/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainExceptionsConstants.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainExceptionsConstants.java
@@ -14,7 +14,8 @@ public final class DomainExceptionsConstants {
     public static final String PHONE_NUMBER_INVALID_LENGTH_MESSAGE = "Phone number length must be between 10 and 13 digits.";
     public static final String USER_UNDER_AGE_VALID_MESSAGE = "User must be of legal age (%d years or older)";
     public static final String EMAIL_INVALID_FORMAT_MESSAGE = "Email format is invalid";
-    public static final String USER_ROLE_OWNER_NOT_ALLOWED_MESSAGE = "Cannot create a user with role '%s' because the current user is not allowed to do.";
+    public static final String ONLY_OWNER_CAN_CREATE_EMPLOYEE = "Only an OWNER can create an EMPLOYEE.";
+    public static final String ONLY_ADMIN_CAN_CREATE_OWNER = "Only an ADMIN can create an OWNER.";
 
     private DomainExceptionsConstants() {
         throw new IllegalStateException("Utility Class");

--- a/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainExceptionsConstants.java
+++ b/src/main/java/com/plazoleta/usermicroservice/domain/utils/constants/DomainExceptionsConstants.java
@@ -14,6 +14,7 @@ public final class DomainExceptionsConstants {
     public static final String PHONE_NUMBER_INVALID_LENGTH_MESSAGE = "Phone number length must be between 10 and 13 digits.";
     public static final String USER_UNDER_AGE_VALID_MESSAGE = "User must be of legal age (%d years or older)";
     public static final String EMAIL_INVALID_FORMAT_MESSAGE = "Email format is invalid";
+    public static final String USER_ROLE_OWNER_NOT_ALLOWED_MESSAGE = "Cannot create a user with role '%s' because the current user is not allowed to do.";
 
     private DomainExceptionsConstants() {
         throw new IllegalStateException("Utility Class");

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/authenticate/AuthenticatedUserAdapter.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/authenticate/AuthenticatedUserAdapter.java
@@ -1,0 +1,38 @@
+package com.plazoleta.usermicroservice.infrastructure.adapters.authenticate;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import com.plazoleta.usermicroservice.domain.ports.out.AuthenticatedUserPort;
+import com.plazoleta.usermicroservice.infrastructure.exceptions.ErrorDecodeAuthoritiesException;
+import com.plazoleta.usermicroservice.infrastructure.exceptions.ErrorDecodeIdException;
+import com.plazoleta.usermicroservice.infrastructure.security.jwt.DecodedJwtHolder;
+
+@Service
+public class AuthenticatedUserAdapter implements AuthenticatedUserPort {
+    
+    @Override
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof DecodedJwtHolder decodedJwtHolder) {
+            return decodedJwtHolder.getUserId();
+        }
+        throw new ErrorDecodeIdException("Could not obtain the authenticated user's ID.");
+    }
+
+    @Override
+    public List<String> getCurrentUserRoles() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof DecodedJwtHolder decodedJwtHolder) {
+            return decodedJwtHolder.getAuthorities()
+                    .stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .toList();
+        }
+        throw new ErrorDecodeAuthoritiesException("Could not obtain the authenticated user's roles.");
+    }
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/persistence/UserPersistenceAdapter.java
@@ -14,6 +14,7 @@ public class UserPersistenceAdapter implements UserPersistencePort {
 
     private final UserRepository userRepository;
     private final UserEntityMapper userEntityMapper;
+    
 
     @Override
     public void save(UserModel userModel) {

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/adapters/persistence/UserPersistenceAdapter.java
@@ -1,24 +1,33 @@
 package com.plazoleta.usermicroservice.infrastructure.adapters.persistence;
 
+import java.util.Optional;
+
+import com.plazoleta.usermicroservice.domain.exceptions.ElementNotFoundException;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
 import com.plazoleta.usermicroservice.domain.ports.out.UserPersistencePort;
 import com.plazoleta.usermicroservice.infrastructure.entities.UserEntity;
 import com.plazoleta.usermicroservice.infrastructure.mappers.UserEntityMapper;
+import com.plazoleta.usermicroservice.infrastructure.repositories.postgres.RoleRepository;
 import com.plazoleta.usermicroservice.infrastructure.repositories.postgres.UserRepository;
-import lombok.RequiredArgsConstructor;
+import com.plazoleta.usermicroservice.infrastructure.utils.constants.InfrastructureMessagesConstants;
 
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class UserPersistenceAdapter implements UserPersistencePort {
 
     private final UserRepository userRepository;
     private final UserEntityMapper userEntityMapper;
-    
+    private final RoleRepository roleRepository;
 
     @Override
     public void save(UserModel userModel) {
         UserEntity userEntity = userEntityMapper.modelToEntity(userModel);
+        var roleName = userModel.getRole().getRoleEnum();
+        var roleEntity = roleRepository.findByName(roleName)
+                .orElseThrow(() -> new ElementNotFoundException(
+                        String.format(InfrastructureMessagesConstants.ROLE_NOT_FOUND, roleName)));
+        userEntity.setRole(roleEntity);
         userRepository.save(userEntity);
     }
 

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/controllers/rest/UserController.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/controllers/rest/UserController.java
@@ -37,8 +37,7 @@ public class UserController {
             @ApiResponse(responseCode = "500", description = "Unexpected server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/")
-    public ResponseEntity<SaveUserResponse> save(
-            @RequestBody SaveUserRequest request) {
+    public ResponseEntity<SaveUserResponse> save(@RequestBody SaveUserRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userHandler.save(request));
     }
 

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
@@ -15,65 +15,72 @@ import com.plazoleta.usermicroservice.domain.exceptions.ElementNotFoundException
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementLengthException;
 import com.plazoleta.usermicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.usermicroservice.domain.exceptions.RoleNotAllowedException;
 import com.plazoleta.usermicroservice.domain.exceptions.UnderAgeException;
 
 @ControllerAdvice
 public class ControllerAdvisor {
 
-    @ExceptionHandler(ElementAlreadyExistsException.class)
-    public ResponseEntity<ExceptionResponse> handleElementAlreadyExistsException(
-            ElementAlreadyExistsException exception) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(ElementAlreadyExistsException.class)
+        public ResponseEntity<ExceptionResponse> handleElementAlreadyExistsException(
+                        ElementAlreadyExistsException exception) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(ElementNotFoundException.class)
-    public ResponseEntity<ExceptionResponse> handleElementNotFoundException(ElementNotFoundException exception) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(ElementNotFoundException.class)
+        public ResponseEntity<ExceptionResponse> handleElementNotFoundException(ElementNotFoundException exception) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(InvalidElementFormatException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidElementFormatException(
-            InvalidElementFormatException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(InvalidElementFormatException.class)
+        public ResponseEntity<ExceptionResponse> handleInvalidElementFormatException(
+                        InvalidElementFormatException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(RequiredFieldsException.class)
-    public ResponseEntity<ExceptionResponse> handleRequiredFieldsException(RequiredFieldsException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(RequiredFieldsException.class)
+        public ResponseEntity<ExceptionResponse> handleRequiredFieldsException(RequiredFieldsException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(InvalidElementLengthException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidElementLengthException(
-            InvalidElementLengthException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(InvalidElementLengthException.class)
+        public ResponseEntity<ExceptionResponse> handleInvalidElementLengthException(
+                        InvalidElementLengthException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(UnderAgeException.class)
-    public ResponseEntity<ExceptionResponse> handleUnderAgeException(UnderAgeException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
-    }
+        @ExceptionHandler(UnderAgeException.class)
+        public ResponseEntity<ExceptionResponse> handleUnderAgeException(UnderAgeException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler({
-            BadCredentialsException.class,
-            UsernameNotFoundException.class,
-            AuthenticationException.class
-    })
-    public ResponseEntity<ExceptionResponse> handleAuthenticationException(Exception exception) {
-        String message = "Invalid username or password.";
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ExceptionResponse(message, LocalDateTime.now()));
-    }
+        @ExceptionHandler(RoleNotAllowedException.class)
+        public ResponseEntity<ExceptionResponse> handleRoleNotAllowedException(RoleNotAllowedException exception) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ExceptionResponse> handleGenericException(Exception exception) {
-        String message = "An unexpected error occurred. Please contact support if the problem persists.";
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ExceptionResponse(message, LocalDateTime.now()));
-    }
+        @ExceptionHandler({
+                        BadCredentialsException.class,
+                        UsernameNotFoundException.class,
+                        AuthenticationException.class
+        })
+        public ResponseEntity<ExceptionResponse> handleAuthenticationException(Exception exception) {
+                String message = "Invalid username or password.";
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(new ExceptionResponse(message, LocalDateTime.now()));
+        }
+
+        @ExceptionHandler(Exception.class)
+        public ResponseEntity<ExceptionResponse> handleGenericException(Exception exception) {
+                String message = "An unexpected error occurred. Please contact support if the problem persists.";
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .body(new ExceptionResponse(message, LocalDateTime.now()));
+        }
 }

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/ErrorDecodeAuthoritiesException.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/ErrorDecodeAuthoritiesException.java
@@ -1,0 +1,9 @@
+package com.plazoleta.usermicroservice.infrastructure.exceptions;
+
+public class ErrorDecodeAuthoritiesException extends IllegalArgumentException {
+
+    public ErrorDecodeAuthoritiesException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/ErrorDecodeIdException.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/ErrorDecodeIdException.java
@@ -1,0 +1,9 @@
+package com.plazoleta.usermicroservice.infrastructure.exceptions;
+
+public class ErrorDecodeIdException extends IllegalArgumentException {
+
+    public ErrorDecodeIdException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/exceptions/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.plazoleta.usermicroservice.infrastructure.exceptions;
+
+public class UserNotFoundException extends IllegalStateException {
+    
+    public UserNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/repositories/postgres/RoleRepository.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/repositories/postgres/RoleRepository.java
@@ -1,0 +1,14 @@
+package com.plazoleta.usermicroservice.infrastructure.repositories.postgres;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.plazoleta.usermicroservice.domain.enums.RoleName;
+import com.plazoleta.usermicroservice.infrastructure.entities.RolEntity;
+
+public interface RoleRepository extends JpaRepository<RolEntity, Long> {
+
+    Optional<RolEntity> findByName(RoleName name);
+    
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(http -> {
                     http.requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs*/**").permitAll();
                     http.requestMatchers(HttpMethod.POST, "/api/v1/auth/").permitAll();
-                    http.requestMatchers(HttpMethod.POST, "/api/v1/user/").hasAuthority("ADMIN");
+                    http.requestMatchers(HttpMethod.POST, "/api/v1/user/").hasAnyAuthority("ADMIN", "OWNER");
                     http.requestMatchers(HttpMethod.GET, "/api/v1/user/{id}").permitAll();
 
                     http.anyRequest().denyAll();

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/jwt/DecodedJwtHolder.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/jwt/DecodedJwtHolder.java
@@ -1,0 +1,33 @@
+package com.plazoleta.usermicroservice.infrastructure.security.jwt;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import lombok.Getter;
+
+@Getter
+public class DecodedJwtHolder extends User {
+    
+    private final Long userId;
+    
+    public DecodedJwtHolder(String username, String password, Collection<? extends GrantedAuthority> authorities, Long userId) {
+        super(username, password, authorities);
+        this.userId = userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        DecodedJwtHolder that = (DecodedJwtHolder) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId);
+    }
+}

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/jwt/JwtTokenValidator.java
@@ -40,11 +40,16 @@ public class JwtTokenValidator extends OncePerRequestFilter {
             
             String username = jwtUtils.extractUsername(decodedJWT);
             String stringAuthorities = jwtUtils.getSpecificClaim(decodedJWT, "authorities").asString();
+            Long userId = jwtUtils.extractUserId(decodedJWT);
 
             Collection<? extends GrantedAuthority> authorities = AuthorityUtils.commaSeparatedStringToAuthorityList(stringAuthorities);
 
             SecurityContext context = SecurityContextHolder.getContext();
-            Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    new DecodedJwtHolder(username, "", authorities, userId),
+                    null,
+                    authorities
+            );
             context.setAuthentication(authentication);
             SecurityContextHolder.setContext(context);
         }

--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/utils/constants/InfrastructureMessagesConstants.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/utils/constants/InfrastructureMessagesConstants.java
@@ -1,0 +1,11 @@
+package com.plazoleta.usermicroservice.infrastructure.utils.constants;
+
+public final class InfrastructureMessagesConstants {
+
+    public static final String ROLE_NOT_FOUND = "Role with name '%s' not found";
+
+    private InfrastructureMessagesConstants() {
+        throw new IllegalStateException("Utility class");
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,6 @@ jwt:
 
 # Uncomment the following lines to enable debug logging
 
-logging:
- level:
-   root: debug
+# logging:
+#  level:
+#    root: debug

--- a/src/test/java/com/plazoleta/usermicroservice/domain/model/RoleModelTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/model/RoleModelTest.java
@@ -1,0 +1,29 @@
+package com.plazoleta.usermicroservice.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.plazoleta.usermicroservice.domain.enums.RoleName;
+import org.junit.jupiter.api.Test;
+
+class RoleModelTest {
+    @Test
+    void testRoleModelGettersAndSetters() {
+        // Arrange
+        RoleModel role = new RoleModel(1L, RoleName.OWNER, "Owner role");
+
+        // Assert constructor and getters
+        assertEquals(1L, role.getId());
+        assertEquals(RoleName.OWNER, role.getRoleEnum());
+        assertEquals("Owner role", role.getDescription());
+
+        // Setters
+        role.setId(2L);
+        role.setRoleEnum(RoleName.ADMIN);
+        role.setDescription("Admin role");
+
+        // Assert setters
+        assertEquals(2L, role.getId());
+        assertEquals(RoleName.ADMIN, role.getRoleEnum());
+        assertEquals("Admin role", role.getDescription());
+    }
+}

--- a/src/test/java/com/plazoleta/usermicroservice/domain/model/UserModelTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/model/UserModelTest.java
@@ -1,0 +1,48 @@
+package com.plazoleta.usermicroservice.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.plazoleta.usermicroservice.domain.enums.RoleName;
+import org.junit.jupiter.api.Test;
+
+class UserModelTest {
+    @Test
+    void testUserModelGettersAndSetters() {
+        // Arrange
+        RoleModel role = new RoleModel(1L, RoleName.OWNER, "Owner role");
+        UserModel user = new UserModel(10L, "John", "Doe", "12345678", "+573001234567", "1990-01-01", "john@mail.com", "password", role);
+
+        // Assert constructor and getters
+        assertEquals(10L, user.getId());
+        assertEquals("John", user.getName());
+        assertEquals("Doe", user.getLastName());
+        assertEquals("12345678", user.getDocumentId());
+        assertEquals("+573001234567", user.getPhoneNumber());
+        assertEquals("1990-01-01", user.getBirthDate());
+        assertEquals("john@mail.com", user.getEmail());
+        assertEquals("password", user.getPassword());
+        assertEquals(role, user.getRole());
+
+        // Setters
+        user.setName("Jane");
+        user.setLastName("Smith");
+        user.setDocumentId("87654321");
+        user.setPhoneNumber("+573009876543");
+        user.setBirthDate("1995-05-05");
+        user.setEmail("jane@mail.com");
+        user.setPassword("newpass");
+        RoleModel newRole = new RoleModel(2L, RoleName.ADMIN, "Admin role");
+        user.setRole(newRole);
+
+        // Assert setters
+        assertEquals(10L, user.getId());
+        assertEquals("Jane", user.getName());
+        assertEquals("Smith", user.getLastName());
+        assertEquals("87654321", user.getDocumentId());
+        assertEquals("+573009876543", user.getPhoneNumber());
+        assertEquals("1995-05-05", user.getBirthDate());
+        assertEquals("jane@mail.com", user.getEmail());
+        assertEquals("newpass", user.getPassword());
+        assertEquals(newRole, user.getRole());
+    }
+}

--- a/src/test/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCaseTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/usecases/UserUseCaseTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,8 +17,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.ElementAlreadyExistsException;
+import com.plazoleta.usermicroservice.domain.exceptions.ElementNotFoundException;
+import com.plazoleta.usermicroservice.domain.exceptions.RoleNotAllowedException;
+import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.usermicroservice.domain.ports.out.PasswordEncoderPort;
 import com.plazoleta.usermicroservice.domain.ports.out.UserPersistencePort;
 import com.plazoleta.usermicroservice.domain.utils.constants.DomainConstants;
@@ -31,6 +37,8 @@ class UserUseCaseTest {
     private PasswordEncoderPort passwordEncoderPort;
     @Mock
     private UserValidatorChain userValidatorChain;
+    @Mock
+    private AuthenticatedUserPort authenticatedUserPort;
 
     @InjectMocks
     private UserUseCase userUseCase;
@@ -49,13 +57,15 @@ class UserUseCaseTest {
                 "1990-01-01",
                 "test@mail.com",
                 "plainpass",
-                null
-        );
+                new RoleModel(1L, RoleName.OWNER, "Owner role"));
+        // Default: user has ADMIN role for positive tests
+        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(List.of(DomainConstants.ROLE_ADMIN));
     }
 
     @Test
     void when_saveUserWithUniqueFields_then_userIsSaved() {
         // Arrange
+        // (roles already set in setUp)
         when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.empty());
         when(userPersistencePort.getUserByEmail(userModel.getEmail())).thenReturn(Optional.empty());
         when(userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber())).thenReturn(Optional.empty());
@@ -68,12 +78,13 @@ class UserUseCaseTest {
         verify(userValidatorChain, times(1)).validate(userModel);
         verify(userPersistencePort, times(1)).save(userModel);
         assertEquals("encodedpass", userModel.getPassword());
-        assertEquals(DomainConstants.OWNER_ROLE, userModel.getRole());
+        assertEquals("OWNER", userModel.getRole().getRoleEnum().name());
     }
 
     @Test
     void when_saveUserWithExistingDocumentId_then_throwException() {
         // Arrange
+        // (roles already set in setUp)
         when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.of(userModel));
 
         // Act & Assert
@@ -85,6 +96,7 @@ class UserUseCaseTest {
     @Test
     void when_saveUserWithExistingEmail_then_throwException() {
         // Arrange
+        // (roles already set in setUp)
         when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.empty());
         when(userPersistencePort.getUserByEmail(userModel.getEmail())).thenReturn(Optional.of(userModel));
 
@@ -97,6 +109,7 @@ class UserUseCaseTest {
     @Test
     void when_saveUserWithExistingPhone_then_throwException() {
         // Arrange
+        // (roles already set in setUp)
         when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.empty());
         when(userPersistencePort.getUserByEmail(userModel.getEmail())).thenReturn(Optional.empty());
         when(userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber())).thenReturn(Optional.of(userModel));
@@ -105,5 +118,81 @@ class UserUseCaseTest {
         assertThrows(ElementAlreadyExistsException.class, () -> userUseCase.save(userModel));
         verify(userValidatorChain, times(1)).validate(userModel);
         verify(userPersistencePort, never()).save(any());
+    }
+
+    @Test
+    void when_saveUserWithRoleOwnerAndNoAdminRole_then_throwRoleNotAllowedException() {
+        // Arrange
+        userModel.setRole(new RoleModel(2L, RoleName.OWNER, "Owner role"));
+        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(List.of(DomainConstants.ROLE_EMPLOYEE)); // Not
+                                                                                                              // ADMIN
+        when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.empty());
+        when(userPersistencePort.getUserByEmail(userModel.getEmail())).thenReturn(Optional.empty());
+        when(userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RoleNotAllowedException.class, () -> userUseCase.save(userModel));
+        verify(userValidatorChain, times(1)).validate(userModel);
+        verify(userPersistencePort, never()).save(any());
+    }
+
+    @Test
+    void when_saveUserWithRoleEmployeeAndNoOwnerRole_then_throwRoleNotAllowedException() {
+        // Arrange
+        userModel.setRole(new RoleModel(3L, RoleName.EMPLOYEE, "Employee role"));
+        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(List.of(DomainConstants.ROLE_ADMIN)); // Not OWNER
+        when(userPersistencePort.getUserByDocumentId(userModel.getDocumentId())).thenReturn(Optional.empty());
+        when(userPersistencePort.getUserByEmail(userModel.getEmail())).thenReturn(Optional.empty());
+        when(userPersistencePort.getUserByPhoneNumber(userModel.getPhoneNumber())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RoleNotAllowedException.class, () -> userUseCase.save(userModel));
+        verify(userValidatorChain, times(1)).validate(userModel);
+        verify(userPersistencePort, never()).save(any());
+    }
+
+    @Test
+    void when_getUserByIdWithNonExistentId_then_throwElementNotFoundException() {
+        // Arrange
+        Long userId = 999L;
+        when(userPersistencePort.getUserById(userId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ElementNotFoundException.class, () -> userUseCase.getUserById(userId));
+    }
+
+    @Test
+    void when_getUserByIdWithExistingId_then_returnUser() {
+        // Arrange
+        Long userId = 1L;
+        when(userPersistencePort.getUserById(userId)).thenReturn(Optional.of(userModel));
+
+        // Act
+        UserModel result = userUseCase.getUserById(userId);
+
+        // Assert
+        assertEquals(userModel, result);
+    }
+
+    @Test
+    void when_createEmployeeWithoutOwnerRole_then_throwRoleNotAllowedException() {
+        // Arrange
+        userModel.setRole(new com.plazoleta.usermicroservice.domain.model.RoleModel(2L, com.plazoleta.usermicroservice.domain.enums.RoleName.EMPLOYEE, "Employee role"));
+        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(List.of(DomainConstants.ROLE_ADMIN)); // No OWNER
+
+        // Act & Assert
+        RoleNotAllowedException ex = assertThrows(RoleNotAllowedException.class, () -> userUseCase.save(userModel));
+        assertEquals(com.plazoleta.usermicroservice.domain.utils.constants.DomainExceptionsConstants.ONLY_OWNER_CAN_CREATE_EMPLOYEE, ex.getMessage());
+    }
+
+    @Test
+    void when_createOwnerWithoutAdminRole_then_throwRoleNotAllowedException() {
+        // Arrange
+        userModel.setRole(new com.plazoleta.usermicroservice.domain.model.RoleModel(3L, com.plazoleta.usermicroservice.domain.enums.RoleName.OWNER, "Owner role"));
+        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(List.of(DomainConstants.ROLE_EMPLOYEE)); // No ADMIN
+
+        // Act & Assert
+        RoleNotAllowedException ex = assertThrows(RoleNotAllowedException.class, () -> userUseCase.save(userModel));
+        assertEquals(com.plazoleta.usermicroservice.domain.utils.constants.DomainExceptionsConstants.ONLY_ADMIN_CAN_CREATE_OWNER, ex.getMessage());
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/DocumentIdLengthValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/DocumentIdLengthValidatorTest.java
@@ -2,7 +2,11 @@ package com.plazoleta.usermicroservice.domain.utils.validation.chain.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -10,6 +14,7 @@ import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementLengthException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 
 class DocumentIdLengthValidatorTest {
 
@@ -44,5 +49,24 @@ class DocumentIdLengthValidatorTest {
         } else {
             assertThrows(InvalidElementLengthException.class, () -> validator.validate(user));
         }
+    }
+
+    @Test
+    void when_documentIdValid_then_callsNextValidator() {
+        DocumentIdLengthValidator validator = new DocumentIdLengthValidator();
+        UserDataValidator next = mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = new UserModel(
+                null,
+                "Test",
+                "User",
+                "12345678",
+                "+573001234567",
+                "1990-01-01",
+                "test@mail.com",
+                "plainpass",
+                new RoleModel(2L, RoleName.OWNER, "User with seller role"));
+        validator.validate(user);
+        verify(next, times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/DocumentIdValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/DocumentIdValidatorTest.java
@@ -4,6 +4,7 @@ import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -42,5 +43,24 @@ class DocumentIdValidatorTest {
         } else {
             assertThrows(InvalidElementFormatException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_documentIdValid_then_callsNextValidator() {
+        DocumentIdValidator validator = new DocumentIdValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = new UserModel(
+                null,
+                "Test",
+                "User",
+                "12345678",
+                "+573001234567",
+                "1990-01-01",
+                "test@mail.com",
+                "plainpass",
+                new RoleModel(2L, RoleName.OWNER, "User with seller role"));
+        validator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/EmailFormatValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/EmailFormatValidatorTest.java
@@ -4,6 +4,7 @@ import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -50,5 +51,15 @@ class EmailFormatValidatorTest {
         } else {
             assertThrows(InvalidElementFormatException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_emailValid_then_callsNextValidator() {
+        EmailFormatValidator validator = new EmailFormatValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = buildUserWithEmail("user@example.com");
+        validator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/PhoneNumberLengthValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/PhoneNumberLengthValidatorTest.java
@@ -4,6 +4,7 @@ import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementLengthException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,5 +48,15 @@ class PhoneNumberLengthValidatorTest {
         } else {
             assertThrows(InvalidElementLengthException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_phoneNumberLengthValid_then_callsNextValidator() {
+        PhoneNumberLengthValidator validator = new PhoneNumberLengthValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = buildUserWithPhone("+573001234567");
+        validator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/PhoneNumberValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/PhoneNumberValidatorTest.java
@@ -4,6 +4,7 @@ import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatExce
 import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,5 +57,15 @@ class PhoneNumberValidatorTest {
         } else {
             assertThrows(InvalidElementFormatException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_phoneNumberValid_then_callsNextValidator() {
+        PhoneNumberValidator localValidator = new PhoneNumberValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        localValidator.setNextValidator(next);
+        UserModel user = buildUserWithPhone("+573001234567");
+        localValidator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/RequiredAgeValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/RequiredAgeValidatorTest.java
@@ -5,6 +5,7 @@ import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatExce
 import com.plazoleta.usermicroservice.domain.exceptions.UnderAgeException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,5 +48,15 @@ class RequiredAgeValidatorTest {
         } else {
             assertThrows(UnderAgeException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_birthDateValid_then_callsNextValidator() {
+        RequiredAgeValidator validator = new RequiredAgeValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = buildUserWithBirthDate("2000-01-01");
+        validator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/RequiredFieldsValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/RequiredFieldsValidatorTest.java
@@ -4,6 +4,7 @@ import com.plazoleta.usermicroservice.domain.enums.RoleName;
 import com.plazoleta.usermicroservice.domain.exceptions.RequiredFieldsException;
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,5 +71,13 @@ class RequiredFieldsValidatorTest {
                 new RoleModel(2L, RoleName.OWNER, "User with seller role"));
         RequiredFieldsException ex = assertThrows(RequiredFieldsException.class, () -> validator.validate(user));
         assertTrue(ex.getMessage().toLowerCase().contains(field.toLowerCase()));
+    }
+    @Test
+    void when_allFieldsPresent_then_callsNextValidator() {
+        RequiredFieldsValidator localValidator = new RequiredFieldsValidator();
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        localValidator.setNextValidator(next);
+        localValidator.validate(validUser);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(validUser);
     }
 }

--- a/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/StringOnlyValidatorTest.java
+++ b/src/test/java/com/plazoleta/usermicroservice/domain/utils/validation/chain/impl/StringOnlyValidatorTest.java
@@ -5,6 +5,7 @@ import com.plazoleta.usermicroservice.domain.exceptions.InvalidElementFormatExce
 import com.plazoleta.usermicroservice.domain.model.RoleModel;
 import com.plazoleta.usermicroservice.domain.model.UserModel;
 import com.plazoleta.usermicroservice.domain.utils.constants.DomainConstants;
+import com.plazoleta.usermicroservice.domain.utils.validation.chain.UserDataValidator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -53,5 +54,24 @@ class StringOnlyValidatorTest {
         } else {
             assertThrows(InvalidElementFormatException.class, () -> validator.validate(user));
         }
+    }
+
+    @org.junit.jupiter.api.Test
+    void when_stringOnlyFieldValid_then_callsNextValidator() {
+        StringOnlyValidator validator = new StringOnlyValidator(DomainConstants.NAME_FIELD);
+        UserDataValidator next = org.mockito.Mockito.mock(UserDataValidator.class);
+        validator.setNextValidator(next);
+        UserModel user = new UserModel(
+                null,
+                "Juan",
+                "Apellido",
+                "12345678",
+                "+573001234567",
+                "1990-01-01",
+                "test@mail.com",
+                "plainpass",
+                new RoleModel(2L, RoleName.OWNER, "User with seller role"));
+        validator.validate(user);
+        org.mockito.Mockito.verify(next, org.mockito.Mockito.times(1)).validate(user);
     }
 }


### PR DESCRIPTION
This pull request implements the following for HU6 (Create Employee Account):

- Adds the logic to allow only OWNER users to create EMPLOYEE accounts, enforcing business rules.
- Validates all required fields (name, last name, document ID, phone, email, password, role) with a validation chain, following hexagonal architecture.
- Ensures document ID, email, and phone are unique and properly formatted.
- Passwords are encrypted using bcrypt before storage.
- Adds and improves unit tests for domain and validation chain, achieving over 90% coverage.
- All acceptance criteria for HU6 are met and tested.

Please review and merge into develop. This PR is ready for QA and further integration.

---

**Note:** All code and documentation follow project conventions and best practices. If you have any questions or suggestions, feel free to comment.