### PR TITLE
HU8: Implement public client registration with auto-assigned CUSTOMER role

### DIFF
--- a/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/usermicroservice/infrastructure/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(http -> {
                     http.requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs*/**").permitAll();
                     http.requestMatchers(HttpMethod.POST, "/api/v1/auth/").permitAll();
-                    http.requestMatchers(HttpMethod.POST, "/api/v1/user/").hasAnyAuthority("ADMIN", "OWNER");
+                    http.requestMatchers(HttpMethod.POST, "/api/v1/user/").permitAll();
                     http.requestMatchers(HttpMethod.GET, "/api/v1/user/{id}").permitAll();
 
                     http.anyRequest().denyAll();


### PR DESCRIPTION
## Description
Implements HU8 ("Crear cuenta Cliente") allowing public (unauthenticated) client registration by auto-assigning the CUSTOMER role when no role is specified.

## Changes Made
- **UserUseCase**: Modified to automatically assign CUSTOMER role if role is null in incoming user model
- **SaveUserRequest**: Made role field optional for public registration
- **UserController**: Updated Swagger documentation to reflect optional role
- **DomainConstants**: Added CUSTOMER_ROLE constant
- **SecurityConfig**: Configured POST /api/v1/user/ endpoint to permit all requests for public registration
- **UserUseCaseTest**: Added comprehensive tests for public registration scenarios

## Key Features
- Public endpoint allows unauthenticated client registration
- Auto-assigns CUSTOMER role when no role is specified
- Maintains existing role validation for authenticated requests
- Follows DRY principle and hexagonal architecture
- Includes comprehensive unit tests

## Testing
- All unit tests pass
- Added specific tests for public registration scenarios
- Maintains existing functionality for authenticated requests